### PR TITLE
Add timestamp with TZ cast to JSON within row types

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -65,6 +65,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -85,6 +86,7 @@ import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateTimeEncoding.unpackZoneKey;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -93,6 +95,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.UNBOUNDED_LENGTH;
 import static io.trino.type.DateTimes.formatTimestamp;
+import static io.trino.type.DateTimes.formatTimestampWithTimeZone;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static io.trino.util.DateTimeUtils.printDate;
@@ -299,6 +302,9 @@ public final class JsonUtil
             }
             if (type instanceof TimestampType timestampType) {
                 return new TimestampJsonGeneratorWriter(timestampType);
+            }
+            if (type instanceof TimestampWithTimeZoneType timestampWithTimeZoneType) {
+                return new TimestampWithTimeZoneJsonGeneratorWriter(timestampWithTimeZoneType);
             }
             if (type instanceof DateType) {
                 return new DateGeneratorWriter();
@@ -536,6 +542,44 @@ public final class JsonUtil
                 }
 
                 jsonGenerator.writeString(formatTimestamp(type.getPrecision(), epochMicros, fraction, UTC));
+            }
+        }
+    }
+
+    private static class TimestampWithTimeZoneJsonGeneratorWriter
+            implements JsonGeneratorWriter
+    {
+        private final TimestampWithTimeZoneType type;
+
+        public TimestampWithTimeZoneJsonGeneratorWriter(TimestampWithTimeZoneType type)
+        {
+            this.type = type;
+        }
+
+        @Override
+        public void writeJsonValue(JsonGenerator jsonGenerator, Block block, int position)
+                throws IOException
+        {
+            if (block.isNull(position)) {
+                jsonGenerator.writeNull();
+            }
+            else {
+                long epochMicros;
+                int fraction;
+                ZoneId zoneId;
+
+                if (type.isShort()) {
+                    epochMicros = type.getLong(block, position);
+                    fraction = 0;
+                }
+                else {
+                    LongTimestamp timestamp = (LongTimestamp) type.getObject(block, position);
+                    epochMicros = timestamp.getEpochMicros();
+                    fraction = timestamp.getPicosOfMicro();
+                }
+                zoneId = unpackZoneKey(epochMicros).getZoneId();
+
+                jsonGenerator.writeString(formatTimestampWithTimeZone(type.getPrecision(), epochMicros, fraction, zoneId));
             }
         }
     }

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -49,6 +49,7 @@ import io.trino.spi.type.RowType.Field;
 import io.trino.spi.type.SmallintType;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignatureParameter;
@@ -156,6 +157,7 @@ public final class JsonUtil
                 type instanceof VarcharType ||
                 type instanceof JsonType ||
                 type instanceof TimestampType ||
+                type instanceof TimestampWithTimeZoneType ||
                 type instanceof DateType) {
             return true;
         }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

The conversion of row types with a timestamp(3) property does not work. Within this PR this is fixed. 

<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
